### PR TITLE
Pkg 7807 pastdeploy version update

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,28 @@
+BSD 3-Clause License
+Copyright (c) 2015-2024, Anaconda Inc - Anaconda Recipes
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,5 @@
 BSD 3-Clause License
-Copyright (c) 2015-2024, Anaconda Inc - Anaconda Recipes
+Copyright (c) 2018-2025, Anaconda Inc - Anaconda Recipes
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/README.md
+++ b/README.md
@@ -1,0 +1,33 @@
+About pastedeploy-feedstock
+=======================
+
+Feedstock license: [BSD-3-Clause](LICENSE)
+
+Home: https://pylonsproject.org/
+
+Package license: MIT
+
+Summary: Load, configure, and compose WSGI applications and servers
+
+
+Current release info
+====================
+
+| Name | Downloads | Version | Platforms |
+| --- | --- | --- | --- |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-pastedeploy-green.svg)](https://anaconda.org/anaconda/pastedeploy) | [![Conda Downloads](https://img.shields.io/conda/dn/anaconda/pastedeploy.svg)](https://anaconda.org/anaconda/pastedeploy) | [![Conda Version](https://img.shields.io/conda/vn/anaconda/pastedeploy.svg)](https://anaconda.org/anaconda/pastedeploy) | [![Conda Platforms](https://img.shields.io/conda/pn/anaconda/pastedeploy.svg)](https://anaconda.org/anaconda/pastedeploy) |
+
+Installing pastedeploy
+==================
+
+Installing `pastedeploy` from the main channel can be achieved by:
+
+```
+conda install pastedeploy
+```
+
+It is possible to list all of the versions of `pastedeploy` available on your platform with `conda`:
+
+```
+conda search pastedeploy
+```

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "PasteDeploy" %}
-{% set version = "2.0.1" %}
+{% set version = "3.1.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: d423fb9d51fdcf853aa4ff43ac7ec469b643ea19590f67488122d6d0d772350a
+  sha256: 9ddbaf152f8095438a9fe81f82c78a6714b92ae8e066bed418b6a7ff6a095a95
 
 build:
   number: 0
@@ -28,17 +28,17 @@ test:
     - paste.deploy
 
 about:
-  home: http://pythonpaste.org/deploy/
+  home: https://pylonsproject.org/
   license: MIT
   license_family: MIT
   summary: Load, configure, and compose WSGI applications and servers
   description: |
-    For WSGI application consumers Paste Deployment provides a single, simple
-    function (loadapp) for loading a WSGI application from a configuration file
-    or a Python Egg.
-  doc_url: http://pastedeploy.readthedocs.io/en/latest/
-  doc_source_url: https://bitbucket.org/ianb/pastedeploy/src/default/docs/index.txt
-  dev_url: https://bitbucket.org/ianb/pastedeploy
+    This tool provides code to load WSGI applications and servers from URIs.
+    These URIs can refer to Python eggs for INI-style configuration files.
+    Paste Script provides commands to serve applications based on this configuration file.
+  doc_url: https://docs.pylonsproject.org/projects/pastedeploy/
+  doc_source_url: https://github.com/Pylons/pastedeploy/tree/main/docs
+  dev_url: https://github.com/Pylons/pastedeploy
 
 extras:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,25 +11,33 @@ source:
 
 build:
   number: 0
-  skip: true
+  skip: true # [py<37] 
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:
   host:
     - python
+    - pip
+    - wheel
     - setuptools >=41
   run:
     - python
+    - importlib-metadata  # [py<38]
 
 test:
   imports:
     - paste
     - paste.deploy
+  requires:
+    - pip
+  commands:
+    - pip check
 
 about:
-  home: https://pylonsproject.org/
+  home: https://docs.pylonsproject.org/projects/pastedeploy
   license: MIT
   license_family: MIT
+  license_file: license.txt
   summary: Load, configure, and compose WSGI applications and servers
   description: |
     This tool provides code to load WSGI applications and servers from URIs.
@@ -41,3 +49,4 @@ about:
 extras:
   recipe-maintainers:
     - mingwandroid
+    - mgralczyk

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,10 +28,17 @@ test:
   imports:
     - paste
     - paste.deploy
+    - paste.deploy.config
+    - paste.deploy.converters
+    - paste.deploy.util
+  source_files:
+    - tests
   requires:
     - pip
+    - pytest
   commands:
     - pip check
+    - pytest -v tests
 
 about:
   home: https://docs.pylonsproject.org/projects/pastedeploy

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -40,8 +40,9 @@ test:
   commands:
     - sed -i "s/\//\\\\/g" tests\sample_configs\test_config.ini # [win]
     - pip check
-    - pytest -v tests -k "not test_interpolate_exception" # [win]
     - pytest -v tests # [not win]
+    # Skip due to issue with paths on Windows (affects only test)
+    - pytest -v tests -k "not test_interpolate_exception" # [win]
 
 about:
   home: https://docs.pylonsproject.org/projects/pastedeploy

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,16 +11,15 @@ source:
 
 build:
   number: 0
-  script: python setup.py install --single-version-externally-managed --record=record.txt
+  skip: true
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:
   host:
     - python
-    - setuptools
-    - pytest-runner
+    - setuptools >=41
   run:
     - python
-    - setuptools
 
 test:
   imports:
@@ -37,7 +36,6 @@ about:
     These URIs can refer to Python eggs for INI-style configuration files.
     Paste Script provides commands to serve applications based on this configuration file.
   doc_url: https://docs.pylonsproject.org/projects/pastedeploy/
-  doc_source_url: https://github.com/Pylons/pastedeploy/tree/main/docs
   dev_url: https://github.com/Pylons/pastedeploy
 
 extras:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,7 +36,9 @@ test:
   requires:
     - pip
     - pytest
+    - msys2-sed  # [win]
   commands:
+    - sed -i "s/\//\\\\/g" tests\sample_configs\test_config.ini # [win]
     - pip check
     - pytest -v tests
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -40,7 +40,8 @@ test:
   commands:
     - sed -i "s/\//\\\\/g" tests\sample_configs\test_config.ini # [win]
     - pip check
-    - pytest -v tests
+    - pytest -v tests -k "not test_interpolate_exception" # [win]
+    - pytest -v tests # [not win]
 
 about:
   home: https://docs.pylonsproject.org/projects/pastedeploy


### PR DESCRIPTION
pastedeploy 3.1.0

**Destination channel:** Defaults

### Links

- [PKG-7807](https://anaconda.atlassian.net/browse/PKG-7807) 
- dev_url: https://github.com/Pylons/pastedeploy
- conda_forge: https://github.com/conda-forge/pastedeploy-feedstock
- pypi: https://pypi.org/project/PasteDeploy

### Explanation of changes:

- new version number
- update dev_url from Bitbucket to Github
- add README file


[PKG-7807]: https://anaconda.atlassian.net/browse/PKG-7807?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ